### PR TITLE
DM-8970: Small bug in describing the usesimplePsf config var for charImgTask

### DIFF
--- a/DATA/rerun/20160805/config/singleFrameDriver.py
+++ b/DATA/rerun/20160805/config/singleFrameDriver.py
@@ -319,7 +319,7 @@ config.processCcd.charImage.astrometry.wcsFitter.numIter=3
 # 	Valid Range = [0,inf)
 config.processCcd.charImage.astrometry.wcsFitter.order=4
 
-# Number of iterations of detect sources, measure sources, estimate PSF. If useSimplePsf='all_iter' then 2 should be plenty; otherwise more may be wanted.
+# Number of iterations of detect sources, measure sources, estimate PSF. If useSimplePsf is True then 2 should be plenty; otherwise more may be wanted.
 # 	Valid Range = [1,inf)
 config.processCcd.charImage.psfIterations=2
 


### PR DESCRIPTION
useSimplePsf is boolean; it cannot be equal to "all_iter".